### PR TITLE
Install sidekiq code from rails-template generators

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -21,8 +21,6 @@ fi
 
 
 echo "Running Terraform formatter"
-# imitates https://github.com/HHS/Head-Start-TTADP/blob/3b72ff05d94fab4cda877c63d8cd6970f0eeffc7/.githooks/pre-commit
-
 files=$(git diff --cached --name-only terraform)
 for f in $files
 do
@@ -32,4 +30,3 @@ do
     git add "$f"
   fi
 done
-

--- a/Gemfile
+++ b/Gemfile
@@ -65,4 +65,10 @@ group :development, :test do
   gem "bundler-audit", "~> 0.9"
   gem "standard", "~> 1.7"
   gem "i18n-tasks", "~> 0.9"
+  gem "rails_template_18f", "~> 0.4"
+end
+gem "sidekiq", "~> 6.4"
+
+group :test do
+  gem "climate_control", "~> 1.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,10 @@ GEM
     bundler-audit (0.9.0.1)
       bundler (>= 1.2.0, < 3)
       thor (~> 1.0)
+    climate_control (1.0.1)
+    colorize (0.8.1)
     concurrent-ruby (1.1.9)
+    connection_pool (2.2.5)
     crass (1.0.6)
     cssbundling-rails (1.1.0)
       railties (>= 6.0.0)
@@ -139,7 +142,7 @@ GEM
       digest
       net-protocol
       timeout
-    newrelic_rpm (8.4.0)
+    newrelic_rpm (8.5.0)
     nio4r (2.5.8)
     nokogiri (1.13.3-arm64-darwin)
       racc (~> 1.4)
@@ -150,7 +153,7 @@ GEM
     parallel (1.21.0)
     parser (3.1.1.0)
       ast (~> 2.4.1)
-    pg (1.3.2)
+    pg (1.3.3)
     puma (5.6.2)
       nio4r (~> 2.0)
     racc (1.6.0)
@@ -179,6 +182,11 @@ GEM
     rails-i18n (7.0.2)
       i18n (>= 0.7, < 2)
       railties (>= 6.0.0, < 8)
+    rails_template_18f (0.4.1)
+      activesupport (~> 7.0.0)
+      colorize (~> 0.8)
+      railties (~> 7.0.0)
+      thor (~> 1.0)
     railties (7.0.2.2)
       actionpack (= 7.0.2.2)
       activesupport (= 7.0.2.2)
@@ -188,6 +196,7 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.0.6)
+    redis (4.6.0)
     regexp_parser (2.2.1)
     reline (0.3.1)
       io-console (~> 0.5)
@@ -233,6 +242,10 @@ GEM
       sprockets-rails
       tilt
     secure_headers (6.3.3)
+    sidekiq (6.4.1)
+      connection_pool (>= 2.2.2)
+      rack (~> 2.0)
+      redis (>= 4.2.0)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -271,6 +284,7 @@ DEPENDENCIES
   bootsnap
   brakeman (~> 5.2)
   bundler-audit (~> 0.9)
+  climate_control (~> 1.0)
   cssbundling-rails
   debug
   dotenv-rails (~> 2.7)
@@ -281,9 +295,11 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (~> 5.0)
   rails (~> 7.0.2)
+  rails_template_18f (~> 0.4)
   rspec-rails (~> 5.1)
   sassc-rails
   secure_headers (~> 6.3)
+  sidekiq (~> 6.4)
   sprockets-rails
   standard (~> 1.7)
   tzinfo-data

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,4 @@
 web: bin/rails server -p 3000
 js: yarn build --watch
 css: yarn build:css --watch
+worker: bundle exec sidekiq

--- a/app/models/cloud_gov_config.rb
+++ b/app/models/cloud_gov_config.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CloudGovConfig
+  ENV_VARIABLE = "VCAP_SERVICES"
+
+  def self.dig(*path)
+    return nil if ENV[ENV_VARIABLE].blank?
+    first, *rest = path
+    vcap_services[first]&.first&.dig(*rest)
+  end
+
+  def self.vcap_services
+    @vcap_services ||= JSON.parse(ENV[ENV_VARIABLE]).with_indifferent_access
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,6 +20,7 @@ Bundler.require(*Rails.groups)
 
 module EngPracticesDemo
   class Application < Rails::Application
+    config.active_job.queue_adapter = :sidekiq
     config.i18n.fallbacks = [:en]
     config.i18n.available_locales = [:en, :es, :fr, :zh]
     # Initialize configuration defaults for originally generated Rails version.

--- a/config/deployment/production.yml
+++ b/config/deployment/production.yml
@@ -1,3 +1,5 @@
 env: production
 web_instances: 2
 web_memory: 512M
+worker_instances: 1
+worker_memory: 512M

--- a/config/deployment/staging.yml
+++ b/config/deployment/staging.yml
@@ -1,3 +1,5 @@
 env: staging
 web_instances: 1
 web_memory: 256M
+worker_instances: 1
+worker_memory: 256M

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Rails.application.config.to_prepare do
+  redis_url = CloudGovConfig.dig "aws-elasticache-redis", "credentials", "uri"
+  if redis_url.present?
+    Sidekiq.configure_server do |config|
+      config.redis = {url: redis_url, ssl: true}
+    end
+
+    Sidekiq.configure_client do |config|
+      config.redis = {url: redis_url, ssl: true}
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,9 @@
+require "sidekiq/web"
+
 Rails.application.routes.draw do
+  if Rails.env.development?
+    mount Sidekiq::Web => "/sidekiq"
+  end
   scope "(:locale)", locale: /#{I18n.available_locales.join('|')}/ do
     # Your application routes here
     root "pages#home"

--- a/doc/compliance/apps/application.boundary.md
+++ b/doc/compliance/apps/application.boundary.md
@@ -29,6 +29,8 @@ Boundary(aws, "AWS GovCloud") {
             System_Boundary(inventory, "Application") {
                 Container(app, "<&layers> Eng Practices Demo", "Ruby 3.0.3, Rails 7.0.2", "TKTK Application Description")
                 ContainerDb(app_db, "Application DB", "AWS RDS (PostgreSQL)", "Primary data storage")
+                Container(worker, "<&layers> Sidekiq workers", "Ruby 3.0.3, Sidekiq", "Perform background work and data processing")
+                ContainerDb(redis, "Redis Database", "AWS ElastiCache (Redis)", "Background job queue")
                 
             }
         }
@@ -71,6 +73,9 @@ Rel(githuball, cg_api, "Deploy App", "Auth: SpaceDeployer Service Account, https
 
 Rel(developer, newrelic, "Manage performance", "https (443)")
 
+Rel(app, redis, "enqueue job parameters", "redis")
+Rel(worker, redis, "dequeues job parameters", "redis")
+Rel(worker, app_db, "reads/writes primary data", "psql (5432)")
 @enduml
 ```
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -11,9 +11,14 @@ applications:
     RAILS_SERVE_STATIC_FILES: true
     NEW_RELIC_LOG: stdout
   processes:
+  - type: worker
+    instances: ((worker_instances))
+    memory: ((worker_memory))
+    command: bundle exec sidekiq
   - type: web
     instances: ((web_instances))
     memory: ((web_memory))
     command: bundle exec rake cf:on_first_instance db:migrate && bundle exec rails s -b 0.0.0.0 -p $PORT -e $RAILS_ENV
   services:
+  - eng_practices_demo-redis-((env))
   - eng_practices_demo-rds-((env))

--- a/spec/models/cloud_gov_config_spec.rb
+++ b/spec/models/cloud_gov_config_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CloudGovConfig, type: :model do
+  subject { described_class }
+
+  describe ".dig" do
+    context "VCAP_SERVICES is blank" do
+      it "returns nil" do
+        expect(subject.dig(:s3, :credentials, :bucket)).to be_nil
+      end
+    end
+
+    context "VCAP_SERVICES is set" do
+      let(:bucket_name) { "bucket-name" }
+      let(:vcap) {
+        {
+          s3: [
+            {
+              credentials: {
+                bucket: bucket_name
+              }
+            }
+          ]
+        }
+      }
+
+      around do |example|
+        ClimateControl.modify VCAP_SERVICES: vcap.to_json do
+          example.run
+        end
+      end
+
+      it "can find a path" do
+        expect(subject.dig(:s3, :credentials, :bucket)).to eq bucket_name
+      end
+
+      it "returns nil for a missing path" do
+        expect(subject.dig(:s3, :credentials, :other)).to be_nil
+      end
+    end
+  end
+end

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -6,10 +6,13 @@ Prerequisite: install the `jq` JSON processor: `brew install jq`
 
 ## Initial setup
 
-1. Manually run the bootstrap module following instructions under `Terraform State Credentials` 
-1. Copy bootstrap credentials to your CI/CD secrets using the instructions in the base README
-1. Create a cloud.gov SpaceDeployer by following the instructions under `SpaceDeployers`
-1. Copy SpaceDeployer credentials to your CI/CD secrets using the instructions in the base README
+1. Manually run the bootstrap module following instructions under `Terraform State Credentials`
+1. Setup CI/CD Pipeline to run Terraform
+  1. Copy bootstrap credentials to your CI/CD secrets using the instructions in the base README
+  1. Create a cloud.gov SpaceDeployer by following the instructions under `SpaceDeployers`
+  1. Copy SpaceDeployer credentials to your CI/CD secrets using the instructions in the base README
+1. Manually Running Terraform
+  1. Follow instructions under `Set up a new environment` to create your infrastructure
 
 ## Terraform State Credentials
 
@@ -147,4 +150,3 @@ In the bootstrap module:
 - `run.sh` Helper script to set up a space deployer and run terraform. The terraform action (`show`/`plan`/`apply`/`destroy`) is passed as an argument
 - `teardown_creds.sh` Helper script to remove the space deployer setup as part of `run.sh`
 - `import.sh` Helper script to create a new local state file in case terraform changes are needed
-

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -17,6 +17,18 @@ module "database" {
   rds_plan_name    = "TKTK-production-rds-plan"
 }
 
+module "redis" {
+  source = "../shared/redis"
+
+  cf_user          = var.cf_user
+  cf_password      = var.cf_password
+  cf_org_name      = local.cf_org_name
+  cf_space_name    = local.cf_space_name
+  env              = local.env
+  recursive_delete = local.recursive_delete
+  redis_plan_name  = "TKTK-production-redis-plan"
+}
+
 
 
 ###########################################################################

--- a/terraform/shared/clamav/main.tf
+++ b/terraform/shared/clamav/main.tf
@@ -1,0 +1,50 @@
+###
+# Target space/org
+###
+
+data "cloudfoundry_space" "space" {
+  org_name = var.cf_org_name
+  name     = var.cf_space_name
+}
+
+data "cloudfoundry_domain" "internal" {
+  name = "apps.internal"
+}
+
+data "cloudfoundry_app" "app" {
+  name_or_id = "eng_practices_demo-${var.env}"
+  space = data.cloudfoundry_space.space.id
+}
+
+###
+# ClamAV API app
+###
+
+resource "cloudfoundry_route" "clamav_route" {
+  space    = data.cloudfoundry_space.space.id
+  domain   = data.cloudfoundry_domain.internal.id
+  hostname = "eng_practices_demo-clamapi-${var.env}"
+}
+
+resource "cloudfoundry_app" "clamav_api" {
+  name         = "eng_practices_demo-clamav-api-${var.env}"
+  space        = data.cloudfoundry_space.space.id
+  memory       = var.clamav_memory
+  disk_quota   = 2048
+  timeout      = 600
+  docker_image = var.clamav_image
+  routes {
+    route = cloudfoundry_route.clamav_route.id
+  }
+  environment = {
+    MAX_FILE_SIZE = var.max_file_size
+  }
+}
+
+resource "cloudfoundry_network_policy" "clamav_routing" {
+  policy {
+    source_app      = data.cloudfoundry_app.app.id
+    destination_app = cloudfoundry_app.clamav_api.id
+    port            = "9443"
+  }
+}

--- a/terraform/shared/clamav/providers.tf
+++ b/terraform/shared/clamav/providers.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = "~> 1.0"
+  required_providers {
+    cloudfoundry = {
+      source  = "cloudfoundry-community/cloudfoundry"
+      version = "0.15.0"
+    }
+  }
+}
+
+provider "cloudfoundry" {
+  api_url      = var.cf_api_url
+  user         = var.cf_user
+  password     = var.cf_password
+  app_logs_max = 30
+}

--- a/terraform/shared/clamav/variables.tf
+++ b/terraform/shared/clamav/variables.tf
@@ -1,0 +1,47 @@
+variable "cf_api_url" {
+  type        = string
+  description = "cloud.gov api url"
+  default     = "https://api.fr.cloud.gov"
+}
+
+variable "cf_user" {
+  type        = string
+  description = "cloud.gov deployer account user"
+}
+
+variable "cf_password" {
+  type        = string
+  description = "secret; cloud.gov deployer account password"
+  sensitive   = true
+}
+
+variable "cf_org_name" {
+  type        = string
+  description = "cloud.gov organization name"
+}
+
+variable "cf_space_name" {
+  type        = string
+  description = "cloud.gov space name (staging or prod)"
+}
+
+variable "env" {
+  type        = string
+  description = "deployment environment (staging, production)"
+}
+
+variable "clamav_image" {
+  type        = string
+  description = "Docker image to deploy the clamav api app"
+}
+
+variable "clamav_memory" {
+  type        = number
+  description = "Memory in MB to allocate to clamav app"
+  default     = 3072
+}
+
+variable "max_file_size" {
+  type        = string
+  description = "Maximum file size the API will accept for scanning"
+}

--- a/terraform/shared/redis/main.tf
+++ b/terraform/shared/redis/main.tf
@@ -1,0 +1,23 @@
+###
+# Target space/org
+###
+
+data "cloudfoundry_space" "space" {
+  org_name = var.cf_org_name
+  name     = var.cf_space_name
+}
+
+###
+# RDS instance
+###
+
+data "cloudfoundry_service" "redis" {
+  name = "aws-elasticache-redis"
+}
+
+resource "cloudfoundry_service_instance" "redis" {
+  name             = "eng_practices_demo-redis-${var.env}"
+  space            = data.cloudfoundry_space.space.id
+  service_plan     = data.cloudfoundry_service.redis.service_plans[var.redis_plan_name]
+  recursive_delete = var.recursive_delete
+}

--- a/terraform/shared/redis/providers.tf
+++ b/terraform/shared/redis/providers.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = "~> 1.0"
+  required_providers {
+    cloudfoundry = {
+      source  = "cloudfoundry-community/cloudfoundry"
+      version = "0.15.0"
+    }
+  }
+}
+
+provider "cloudfoundry" {
+  api_url      = var.cf_api_url
+  user         = var.cf_user
+  password     = var.cf_password
+  app_logs_max = 30
+}

--- a/terraform/shared/redis/variables.tf
+++ b/terraform/shared/redis/variables.tf
@@ -1,0 +1,42 @@
+variable "cf_api_url" {
+  type        = string
+  description = "cloud.gov api url"
+  default     = "https://api.fr.cloud.gov"
+}
+
+variable "cf_user" {
+  type        = string
+  description = "cloud.gov deployer account user"
+}
+
+variable "cf_password" {
+  type        = string
+  description = "secret; cloud.gov deployer account password"
+  sensitive   = true
+}
+
+variable "cf_org_name" {
+  type        = string
+  description = "cloud.gov organization name"
+}
+
+variable "cf_space_name" {
+  type        = string
+  description = "cloud.gov space name (staging or prod)"
+}
+
+variable "env" {
+  type        = string
+  description = "deployment environment (staging, production)"
+}
+
+variable "recursive_delete" {
+  type        = bool
+  description = "when true, deletes service bindings attached to the resource (not recommended for production)"
+  default     = false
+}
+
+variable "redis_plan_name" {
+  type        = string
+  description = "name of the service plan name to create"
+}

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -17,3 +17,16 @@ module "database" {
   rds_plan_name    = "micro-psql"
 }
 
+module "redis" {
+  source = "../shared/redis"
+
+  cf_user          = var.cf_user
+  cf_password      = var.cf_password
+  cf_org_name      = local.cf_org_name
+  cf_space_name    = local.cf_space_name
+  env              = local.env
+  recursive_delete = local.recursive_delete
+  redis_plan_name  = "redis-dev"
+}
+
+


### PR DESCRIPTION
Example of updating a rails app using the rails-template generators.

Here we ran:

1. `rails g rails_template18f:sidekiq` to install sidekiq for ActiveJob processing
2. `rails g rails_template18f:terraform` to update the terraform code with a redis service